### PR TITLE
feat: use backend api key for requests

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,7 +9,6 @@ frontend:
       commands:
         - env | grep -e WALTER_BACKEND_API_URL >> .env.production
         - env | grep -e WALTER_BACKEND_API_KEY >> .env.production
-        - env | grep -e NEXT_PUBLIC_ >> .env.production
         - pnpm run build
   artifacts:
     baseDirectory: .next

--- a/amplify.yml
+++ b/amplify.yml
@@ -4,10 +4,12 @@ frontend:
     preBuild:
       commands:
         - npm install -g pnpm
-        - export WALTER_BACKEND_API_URL=https://dev-api.walterai.dev
         - pnpm install
     build:
       commands:
+        - env | grep -e WALTER_BACKEND_API_URL >> .env.production
+        - env | grep -e WALTER_BACKEND_API_KEY >> .env.production
+        - env | grep -e NEXT_PUBLIC_ >> .env.production
         - pnpm run build
   artifacts:
     baseDirectory: .next

--- a/src/layouts/AuthenticatedPageLayout.tsx
+++ b/src/layouts/AuthenticatedPageLayout.tsx
@@ -6,8 +6,7 @@ import Sidebar from '@/components/sidebars/Sidebar';
 import UserProfileMenu from '@/components/users/UserProfileMenu';
 import { User } from '@/lib/models/User';
 
-import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
-import { Bars3Icon, BellIcon } from '@heroicons/react/24/outline';
+import { Bars3Icon } from '@heroicons/react/24/outline';
 
 const AuthenticatedPageLayout: React.FC<{
   pageName: string;
@@ -34,33 +33,13 @@ const AuthenticatedPageLayout: React.FC<{
 
             <div aria-hidden="true" className="h-6 w-px bg-gray-900/10 lg:hidden" />
 
-            <div className="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
-              <form action="#" method="GET" className="grid flex-1 grid-cols-1">
-                <input
-                  name="search"
-                  type="search"
-                  placeholder="Search"
-                  aria-label="Search"
-                  className="col-start-1 row-start-1 block size-full bg-white pl-8 text-base text-gray-900 outline-hidden placeholder:text-gray-400 sm:text-sm/6"
-                />
-                <MagnifyingGlassIcon
-                  aria-hidden="true"
-                  className="pointer-events-none col-start-1 row-start-1 size-5 self-center text-gray-400"
-                />
-              </form>
-              <div className="flex items-center gap-x-4 lg:gap-x-6">
-                <button type="button" className="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500">
-                  <span className="sr-only">View notifications</span>
-                  <BellIcon aria-hidden="true" className="size-6" />
-                </button>
+            <div className="flex items-center gap-x-4 lg:gap-x-6">
+              <div
+                aria-hidden="true"
+                className="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10"
+              />
 
-                <div
-                  aria-hidden="true"
-                  className="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10"
-                />
-
-                <UserProfileMenu user={user} />
-              </div>
+              <UserProfileMenu user={user} />
             </div>
           </div>
 

--- a/src/lib/backend/client.ts
+++ b/src/lib/backend/client.ts
@@ -9,28 +9,52 @@ import { HttpStatus } from '@/lib/proxy/statuses';
  ****************************/
 
 export class WalterBackend {
-  static readonly API_URL: string = process.env.NEXT_PUBLIC_WALTER_BACKEND_API_URL as string;
-
   static readonly REFRESH_TOKEN_KEY: string = 'WALTER_BACKEND_REFRESH_TOKEN';
   static readonly ACCESS_TOKEN_KEY: string = 'WALTER_BACKEND_ACCESS_TOKEN';
 
-  public static async login(email: string, password: string): Promise<AxiosResponse> {
-    return this.callBackend(API_ENDPOINTS['LOGIN'].method, API_ENDPOINTS['LOGIN'].path, undefined, {
-      email,
-      password,
-    });
-  }
-
-  public static async logout(token: string): Promise<AxiosResponse> {
-    return this.callBackend(API_ENDPOINTS['LOGOUT'].method, API_ENDPOINTS['LOGOUT'].path, token);
-  }
-
-  public static async refresh(token: string): Promise<AxiosResponse> {
-    return this.callBackend(API_ENDPOINTS['REFRESH'].method, API_ENDPOINTS['REFRESH'].path, token);
-  }
-
-  public static async getUser(token: string): Promise<AxiosResponse> {
+  public static async login(
+    url: string,
+    key: string,
+    email: string,
+    password: string
+  ): Promise<AxiosResponse> {
     return this.callBackend(
+      url,
+      key,
+      API_ENDPOINTS['LOGIN'].method,
+      API_ENDPOINTS['LOGIN'].path,
+      undefined,
+      {
+        email,
+        password,
+      }
+    );
+  }
+
+  public static async logout(url: string, key: string, token: string): Promise<AxiosResponse> {
+    return this.callBackend(
+      url,
+      key,
+      API_ENDPOINTS['LOGOUT'].method,
+      API_ENDPOINTS['LOGOUT'].path,
+      token
+    );
+  }
+
+  public static async refresh(url: string, key: string, token: string): Promise<AxiosResponse> {
+    return this.callBackend(
+      url,
+      key,
+      API_ENDPOINTS['REFRESH'].method,
+      API_ENDPOINTS['REFRESH'].path,
+      token
+    );
+  }
+
+  public static async getUser(url: string, key: string, token: string): Promise<AxiosResponse> {
+    return this.callBackend(
+      url,
+      key,
       API_ENDPOINTS['GET_USER'].method,
       API_ENDPOINTS['GET_USER'].path,
       token
@@ -38,14 +62,18 @@ export class WalterBackend {
   }
 
   public static async createUser(
+    url: string,
+    key: string,
     email: string,
     firstName: string,
     lastName: string,
     password: string
   ): Promise<AxiosResponse> {
     return this.callBackend(
+      url,
+      key,
       API_ENDPOINTS['CREATE_USER'].method,
-      `${this.API_URL}${API_ENDPOINTS['CREATE_USER'].path}`,
+      API_ENDPOINTS['CREATE_USER'].path,
       undefined,
       {
         email: email,
@@ -56,24 +84,38 @@ export class WalterBackend {
     );
   }
 
-  public static async getAccounts(token: string): Promise<AxiosResponse> {
+  public static async getAccounts(url: string, key: string, token: string): Promise<AxiosResponse> {
     return this.callBackend(
+      url,
+      key,
       API_ENDPOINTS['GET_ACCOUNTS'].method,
       API_ENDPOINTS['GET_ACCOUNTS'].path,
       token
     );
   }
 
-  public static async getTransactions(token: string): Promise<AxiosResponse> {
+  public static async getTransactions(
+    url: string,
+    key: string,
+    token: string
+  ): Promise<AxiosResponse> {
     return this.callBackend(
+      url,
+      key,
       API_ENDPOINTS['GET_TRANSACTIONS'].method,
       API_ENDPOINTS['GET_TRANSACTIONS'].path,
       token
     );
   }
 
-  public static async createLinkToken(token: string): Promise<AxiosResponse> {
+  public static async createLinkToken(
+    url: string,
+    key: string,
+    token: string
+  ): Promise<AxiosResponse> {
     return this.callBackend(
+      url,
+      key,
       API_ENDPOINTS['CREATE_LINK_TOKEN'].method,
       API_ENDPOINTS['CREATE_LINK_TOKEN'].path,
       token
@@ -81,6 +123,8 @@ export class WalterBackend {
   }
 
   public static async exchangePublicToken(
+    url: string,
+    key: string,
     token: string,
     publicToken: string,
     institutionId: string,
@@ -94,6 +138,8 @@ export class WalterBackend {
     }[]
   ): Promise<AxiosResponse> {
     return this.callBackend(
+      url,
+      key,
       API_ENDPOINTS['EXCHANGE_PUBLIC_TOKEN'].method,
       API_ENDPOINTS['EXCHANGE_PUBLIC_TOKEN'].path,
       token,
@@ -107,11 +153,15 @@ export class WalterBackend {
   }
 
   public static syncTransactions(
+    url: string,
+    key: string,
     token: string,
     userId: string,
     accountId: string
   ): Promise<AxiosResponse> {
     return this.callBackend(
+      url,
+      key,
       API_ENDPOINTS['SYNC_TRANSACTIONS'].method,
       API_ENDPOINTS['SYNC_TRANSACTIONS'].path,
       token,
@@ -122,8 +172,12 @@ export class WalterBackend {
     );
   }
 
-  public static async refreshCookies(refreshToken: string): Promise<string[]> {
-    const refreshResponse: AxiosResponse = await WalterBackend.refresh(refreshToken);
+  public static async refreshCookies(
+    url: string,
+    key: string,
+    refreshToken: string
+  ): Promise<string[]> {
+    const refreshResponse: AxiosResponse = await WalterBackend.refresh(url, key, refreshToken);
 
     if (refreshResponse.status === HttpStatus.OK) {
       const cookies: string[] | undefined = refreshResponse.headers['set-cookie'];
@@ -157,6 +211,8 @@ export class WalterBackend {
   }
 
   private static async callBackend(
+    url: string,
+    key: string,
     method: string,
     path: string,
     token?: string,
@@ -164,15 +220,20 @@ export class WalterBackend {
   ): Promise<AxiosResponse> {
     const config: any = {
       method: method,
-      url: `${this.API_URL}${path}`,
+      url: `${url}${path}`,
       validateStatus: function (status: number): boolean {
         return true;
       },
     };
 
+    const headers: Record<string, string> = {};
+    headers['x-api-key'] = key;
+
     if (token) {
-      config.headers = { Authorization: `Bearer ${token}` };
+      headers['Authorization'] = `Bearer ${token}`;
     }
+
+    config.headers = headers;
 
     if (data) {
       config.data = data;

--- a/src/pages/api/accounts/get-accounts.ts
+++ b/src/pages/api/accounts/get-accounts.ts
@@ -4,10 +4,24 @@ import { AxiosResponse } from 'axios';
 import { WalterBackend } from '@/lib/backend/client';
 import { HttpStatus } from '@/lib/proxy/statuses';
 
+const API_NAME: string = 'GetAccounts';
+
 export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ): Promise<void> {
+  const apiUrl: string | undefined = process.env.WALTER_BACKEND_API_URL;
+  const apiKey: string | undefined = process.env.WALTER_BACKEND_API_KEY;
+
+  if (!apiUrl || !apiKey) {
+    console.error(
+      `WalterBackend API URL or API key is missing in ${API_NAME} API proxy request. Not calling WalterBackend.`
+    );
+    return response
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .json({ error: 'Internal Server Error' });
+  }
+
   if (request.method !== 'GET') {
     return response.status(HttpStatus.METHOD_NOT_ALLOWED).json({ error: 'Method not allowed' });
   }
@@ -23,13 +37,21 @@ export default async function handler(
   }
 
   try {
-    const backendResponse: AxiosResponse = await WalterBackend.getAccounts(accessToken);
+    const backendResponse: AxiosResponse = await WalterBackend.getAccounts(
+      apiUrl,
+      apiKey,
+      accessToken
+    );
 
     if (backendResponse.status === HttpStatus.UNAUTHORIZED) {
-      const cookies: string[] = await WalterBackend.refreshCookies(refreshToken);
+      const cookies: string[] = await WalterBackend.refreshCookies(apiUrl, apiKey, refreshToken);
       response.setHeader('Set-Cookie', cookies);
       const newAccessToken: string = WalterBackend.getAccessTokenFromCookies(cookies);
-      const backendRetryResponse: AxiosResponse = await WalterBackend.getAccounts(newAccessToken);
+      const backendRetryResponse: AxiosResponse = await WalterBackend.getAccounts(
+        apiUrl,
+        apiKey,
+        newAccessToken
+      );
       return response.status(backendRetryResponse.status).json(backendRetryResponse.data);
     }
 

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -2,8 +2,21 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { AxiosResponse } from 'axios';
 
 import { WalterBackend } from '@/lib/backend/client';
+import { HttpStatus } from '@/lib/proxy/statuses';
+
+const API_NAME: string = 'Login';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  const apiUrl: string | undefined = process.env.WALTER_BACKEND_API_URL;
+  const apiKey: string | undefined = process.env.WALTER_BACKEND_API_KEY;
+
+  if (!apiUrl || !apiKey) {
+    console.error(
+      `WalterBackend API URL or API key is missing in ${API_NAME} API proxy request. Not calling WalterBackend.`
+    );
+    return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({ error: 'Internal Server Error' });
+  }
+
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
@@ -15,7 +28,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const backendResponse: AxiosResponse = await WalterBackend.login(email, password);
+    const backendResponse: AxiosResponse = await WalterBackend.login(
+      apiUrl,
+      apiKey,
+      email,
+      password
+    );
 
     const cookies: string[] | undefined = backendResponse.headers['set-cookie'];
     if (cookies) {

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -4,10 +4,24 @@ import { AxiosResponse } from 'axios';
 import { WalterBackend } from '@/lib/backend/client';
 import { HttpStatus } from '@/lib/proxy/statuses';
 
+const API_NAME: string = 'Logout';
+
 export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ): Promise<void> {
+  const apiUrl: string | undefined = process.env.WALTER_BACKEND_API_URL;
+  const apiKey: string | undefined = process.env.WALTER_BACKEND_API_KEY;
+
+  if (!apiUrl || !apiKey) {
+    console.error(
+      `WalterBackend API URL or API key is missing in ${API_NAME} API proxy request. Not calling WalterBackend.`
+    );
+    return response
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .json({ error: 'Internal Server Error' });
+  }
+
   if (request.method !== 'POST') {
     return response.status(405).json({ error: 'Method not allowed' });
   }
@@ -23,13 +37,17 @@ export default async function handler(
   }
 
   try {
-    const backendResponse: AxiosResponse = await WalterBackend.logout(accessToken);
+    const backendResponse: AxiosResponse = await WalterBackend.logout(apiUrl, apiKey, accessToken);
 
     if (backendResponse.status === HttpStatus.UNAUTHORIZED) {
-      const cookies: string[] = await WalterBackend.refreshCookies(refreshToken);
+      const cookies: string[] = await WalterBackend.refreshCookies(apiUrl, apiKey, refreshToken);
       response.setHeader('Set-Cookie', cookies);
       const newAccessToken: string = WalterBackend.getAccessTokenFromCookies(cookies);
-      const backendRetryResponse: AxiosResponse = await WalterBackend.logout(newAccessToken);
+      const backendRetryResponse: AxiosResponse = await WalterBackend.logout(
+        apiUrl,
+        apiKey,
+        newAccessToken
+      );
       const retryResponseCookies: string[] | undefined = backendRetryResponse.headers['set-cookie'];
       if (retryResponseCookies) {
         response.setHeader('Set-Cookie', retryResponseCookies);

--- a/src/pages/api/plaid/create-link-token.ts
+++ b/src/pages/api/plaid/create-link-token.ts
@@ -4,10 +4,24 @@ import { AxiosResponse } from 'axios';
 import { WalterBackend } from '@/lib/backend/client';
 import { HttpStatus } from '@/lib/proxy/statuses';
 
+const API_NAME: string = 'CreateLinkToken';
+
 export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ): Promise<void> {
+  const apiUrl: string | undefined = process.env.WALTER_BACKEND_API_URL;
+  const apiKey: string | undefined = process.env.WALTER_BACKEND_API_KEY;
+
+  if (!apiUrl || !apiKey) {
+    console.error(
+      `WalterBackend API URL or API key is missing in ${API_NAME} API proxy request. Not calling WalterBackend.`
+    );
+    return response
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .json({ error: 'Internal Server Error' });
+  }
+
   const accessToken: string | undefined = WalterBackend.getAccessToken(request);
   const refreshToken: string | undefined = WalterBackend.getRefreshToken(request);
 
@@ -19,14 +33,21 @@ export default async function handler(
   }
 
   try {
-    const backendResponse: AxiosResponse = await WalterBackend.createLinkToken(accessToken);
+    const backendResponse: AxiosResponse = await WalterBackend.createLinkToken(
+      apiUrl,
+      apiKey,
+      accessToken
+    );
 
     if (backendResponse.status === HttpStatus.UNAUTHORIZED) {
-      const cookies: string[] = await WalterBackend.refreshCookies(refreshToken);
+      const cookies: string[] = await WalterBackend.refreshCookies(apiUrl, apiKey, refreshToken);
       response.setHeader('Set-Cookie', cookies);
       const newAccessToken: string = WalterBackend.getAccessTokenFromCookies(cookies);
-      const backendRetryResponse: AxiosResponse =
-        await WalterBackend.createLinkToken(newAccessToken);
+      const backendRetryResponse: AxiosResponse = await WalterBackend.createLinkToken(
+        apiUrl,
+        apiKey,
+        newAccessToken
+      );
       return response.status(backendRetryResponse.status).json(backendRetryResponse.data);
     }
 

--- a/src/pages/api/plaid/exchange-public-token.ts
+++ b/src/pages/api/plaid/exchange-public-token.ts
@@ -4,10 +4,24 @@ import { AxiosResponse } from 'axios';
 import { WalterBackend } from '@/lib/backend/client';
 import { HttpStatus } from '@/lib/proxy/statuses';
 
+const API_NAME: string = 'ExchangePublicToken';
+
 export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ): Promise<void> {
+  const apiUrl: string | undefined = process.env.WALTER_BACKEND_API_URL;
+  const apiKey: string | undefined = process.env.WALTER_BACKEND_API_KEY;
+
+  if (!apiUrl || !apiKey) {
+    console.error(
+      `WalterBackend API URL or API key is missing in ${API_NAME} API proxy request. Not calling WalterBackend.`
+    );
+    return response
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .json({ error: 'Internal Server Error' });
+  }
+
   if (request.method !== 'POST') {
     return response.status(405).json({ error: 'Method not allowed' });
   }
@@ -24,6 +38,8 @@ export default async function handler(
 
   try {
     const backendResponse: AxiosResponse = await WalterBackend.exchangePublicToken(
+      apiUrl,
+      apiKey,
       accessToken,
       request.body.publicToken,
       request.body.institutionId,
@@ -32,10 +48,12 @@ export default async function handler(
     );
 
     if (backendResponse.status === HttpStatus.UNAUTHORIZED) {
-      const cookies: string[] = await WalterBackend.refreshCookies(refreshToken);
+      const cookies: string[] = await WalterBackend.refreshCookies(apiUrl, apiKey, refreshToken);
       response.setHeader('Set-Cookie', cookies);
       const newAccessToken: string = WalterBackend.getAccessTokenFromCookies(cookies);
       const backendRetryResponse: AxiosResponse = await WalterBackend.exchangePublicToken(
+        apiUrl,
+        apiKey,
         newAccessToken,
         request.body.publicToken,
         request.body.institutionId,

--- a/src/pages/api/transactions/get-transactions.ts
+++ b/src/pages/api/transactions/get-transactions.ts
@@ -10,6 +10,18 @@ export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ): Promise<void> {
+  const apiUrl: string | undefined = process.env.WALTER_BACKEND_API_URL;
+  const apiKey: string | undefined = process.env.WALTER_BACKEND_API_KEY;
+
+  if (!apiUrl || !apiKey) {
+    console.error(
+      `WalterBackend API URL or API key is missing in ${API_NAME} API proxy request. Not calling WalterBackend.`
+    );
+    return response
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .json({ error: 'Internal Server Error' });
+  }
+
   if (request.method !== 'GET') {
     return response.status(HttpStatus.METHOD_NOT_ALLOWED).json({ error: 'Method not allowed' });
   }
@@ -25,14 +37,21 @@ export default async function handler(
   }
 
   try {
-    const backendResponse: AxiosResponse = await WalterBackend.getTransactions(accessToken);
+    const backendResponse: AxiosResponse = await WalterBackend.getTransactions(
+      apiUrl,
+      apiKey,
+      accessToken
+    );
 
     if (backendResponse.status === HttpStatus.UNAUTHORIZED) {
-      const cookies: string[] = await WalterBackend.refreshCookies(refreshToken);
+      const cookies: string[] = await WalterBackend.refreshCookies(apiUrl, apiKey, refreshToken);
       response.setHeader('Set-Cookie', cookies);
       const newAccessToken: string = WalterBackend.getAccessTokenFromCookies(cookies);
-      const backendRetryResponse: AxiosResponse =
-        await WalterBackend.getTransactions(newAccessToken);
+      const backendRetryResponse: AxiosResponse = await WalterBackend.getTransactions(
+        apiUrl,
+        apiKey,
+        newAccessToken
+      );
       return response.status(backendRetryResponse.status).json(backendRetryResponse.data);
     }
 

--- a/src/pages/api/users/create-user.ts
+++ b/src/pages/api/users/create-user.ts
@@ -4,10 +4,24 @@ import { AxiosResponse } from 'axios';
 import { WalterBackend } from '@/lib/backend/client';
 import { HttpStatus } from '@/lib/proxy/statuses';
 
+const API_NAME: string = 'CreateUser';
+
 export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ): Promise<void> {
+  const apiUrl: string | undefined = process.env.WALTER_BACKEND_API_URL;
+  const apiKey: string | undefined = process.env.WALTER_BACKEND_API_KEY;
+
+  if (!apiUrl || !apiKey) {
+    console.error(
+      `WalterBackend API URL or API key is missing in ${API_NAME} API proxy request. Not calling WalterBackend.`
+    );
+    return response
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .json({ error: 'Internal Server Error' });
+  }
+
   if (request.method !== 'POST') {
     return response.status(HttpStatus.METHOD_NOT_ALLOWED).json({ error: 'Method not allowed' });
   }
@@ -20,6 +34,8 @@ export default async function handler(
 
   try {
     const backendResponse: AxiosResponse = await WalterBackend.createUser(
+      apiUrl,
+      apiKey,
       email,
       firstName,
       lastName,


### PR DESCRIPTION
## Summary

This PR updates the Node proxy to use the process env vars to get the backend URL and API key.

The backend was recently updated to use API keys and restrict access to all endpoints via keys. So, this PR updates the frontend to use the new API key (as an env var) so it can successfully talk to the backend.

## Context

Without this change the frontend will continuously receive `Forbidden` HTTP status responses from the backend 😢 

## Changes

- [X] Updated `amplify.yml` build script to export required env vars to Node proxy
- [X] Updated all proxy methods to use the env vars to create requests to backend with API key

## Testing

E2E testing in development.

## Notes

N/A.
